### PR TITLE
waiting for unix socket to be ready

### DIFF
--- a/gui/start.sh
+++ b/gui/start.sh
@@ -1,3 +1,6 @@
 #!/bin/bash 
-sleep 1m
+
+# Wait for the x11 socket to appear in the shared volume
+while [ ! -e /tmp/.X11-unix/X${DISPLAY#*:} ]; do sleep 0.1; done
+
 python hello.py


### PR DESCRIPTION
We can look for the X11 socket to be ready in order to start the application, rather than sleeping for a long time